### PR TITLE
Move IAM policies from inline to data sources

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 module "iam" {
-  error_sns_topic = var.error_sns_topic
   source          = "./modules/iam"
+  error_sns_topic = var.error_sns_topic
 }
 
 module "archive" {
@@ -9,7 +9,7 @@ module "archive" {
 
 module "lambda" {
   source                       = "./modules/lambda"
-  file_placeholder_output_path = module.archive.file_placeholder_output_path
-  discontent_backend_role_arn  = module.iam.discontent_backend_role_arn
   error_sns_topic              = var.error_sns_topic
+  discontent_backend_role_arn  = module.iam.discontent_backend_role_arn
+  file_placeholder_output_path = module.archive.file_placeholder_output_path
 }

--- a/terraform/modules/archive/main.tf
+++ b/terraform/modules/archive/main.tf
@@ -7,7 +7,3 @@ data "archive_file" "placeholder" {
     filename = "placeholder.txt"
   }
 }
-
-output "file_placeholder_output_path" {
-  value = data.archive_file.placeholder.output_path
-}

--- a/terraform/modules/archive/outputs.tf
+++ b/terraform/modules/archive/outputs.tf
@@ -1,0 +1,3 @@
+output "file_placeholder_output_path" {
+  value = data.archive_file.placeholder.output_path
+}

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,0 +1,3 @@
+output "discontent_backend_role_arn" {
+  value = aws_iam_role.discontent_backend.arn
+}

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -26,11 +26,3 @@ resource "aws_lambda_permission" "discontent_backend" {
   function_name = aws_lambda_function.discontent_backend.arn
   principal     = "apigateway.amazonaws.com"
 }
-
-output "discontent_backend_lambda_arn" {
-  value = aws_lambda_function.discontent_backend.arn
-}
-
-output "discontent_backend_lambda_invoke_arn" {
-  value = aws_lambda_function.discontent_backend.invoke_arn
-}

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -1,0 +1,7 @@
+output "discontent_backend_lambda_arn" {
+  value = aws_lambda_function.discontent_backend.arn
+}
+
+output "discontent_backend_lambda_invoke_arn" {
+  value = aws_lambda_function.discontent_backend.invoke_arn
+}


### PR DESCRIPTION
To allow more flexible due to HCL language features, I converted existing IAM policy resources to render policies from `iam_policy_document` data sources instead of holding the policies inline with customization using string interpolation.

Additionally, I moved outputs to their own dedicated `outputs.tf` files in child modules. This PR is 100% backwards compatible and should result in a zero diff change.